### PR TITLE
Use npm dependency angular-ui-bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "license": "MIT",
   "main": "datetimepicker.js",
   "dependencies": {
-    "angular-bootstrap": ">=1.1.0"
+    "angular-ui-bootstrap": ">=1.1.0"
   }
 }


### PR DESCRIPTION
angular-bootstrap#1.1.0 doesn't exist in the npm registry, therefore npm conflicts and looks for another version. The npm package was renamed to angular-ui-bootstrap.