### PR TITLE
readonlyTime should correspond to ngDisabled

### DIFF
--- a/datetimepicker.js
+++ b/datetimepicker.js
@@ -121,7 +121,7 @@ angular.module('ui.bootstrap.datetimepicker', ["ui.bootstrap.dateparser", "ui.bo
               ["min", "minDate"],
               ["max", "maxDate"],
               ["ngHide", "hiddenTime"],
-              ["readonlyInput", "readonlyTime"]
+              ["ngDisabled", "readonlyTime"]
             ].reduce(createAttrConcat, '') +
             createEvalAttr("showSpinners", "showSpinners") +
             "></timepicker>\n" +


### PR DESCRIPTION
To make readonlyTime function the same way readonlyDate does, it should be bound to the uib-timepicker's ngDisabled attribute instead of the readonlyInput attribute.

You can see the difference when doing this:

    <datetimepicker readonly-date="item.disabled" readonly-time="item.disabled"></datetimepicker>

And changing the value of `item.disabled` after the directive is rendered.