### PR TITLE
Datepicker and Timepicker template url options

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ $scope.isDisabledDate = function(currentDate, mode) {
  	_(Defaults: true)_ :
  	 Shows spinner arrows above and below the inputs.
  
- * `template-url`
+ * `timepicker-template-url`
   _(Defaults: uib/template/timepicker/timepicker.html)_ :
    Add the ability to override the template used on the component.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ $scope.isDisabledDate = function(currentDate, mode) {
  	_(Default: false)_ :
  	Append the datepicker popup element to body, rather than inserting after datepicker-popup.
 
+ * `datepicker-popup-template-url`
+  _(Default: uib/template/datepickerPopup/popup.html)_ :
+  Add the ability to override the template used on the component.
+
+ * `datepicker-template-url`
+  _(Default: uib/template/datepicker/datepicker.html)_ :
+  Add the ability to override the template used on the component (inner uib-datepicker).
+
  * `date-disabled (date, mode)`
  	_(Default: null)_ :
  	An optional expression to disable visible options based on passing date and current mode _(day|month|year)_.
@@ -157,6 +165,10 @@ $scope.isDisabledDate = function(currentDate, mode) {
  * `show-spinners`
  	_(Defaults: true)_ :
  	 Shows spinner arrows above and below the inputs.
+ 
+ * `template-url`
+  _(Defaults: uib/template/timepicker/timepicker.html)_ :
+   Add the ability to override the template used on the component.
 
  * `year-format`
  	_(Default: 'yyyy')_ :

--- a/datetimepicker.js
+++ b/datetimepicker.js
@@ -52,7 +52,10 @@ angular.module('ui.bootstrap.datetimepicker', ["ui.bootstrap.dateparser", "ui.bo
           readonlyDate: "=",
           disabledDate: "=",
           hiddenTime: "=",
-          hiddenDate: "="
+          hiddenDate: "=",
+          datepickerTemplateUrl: "@",
+          datepickerPopupTemplateUrl: "@",
+          timepickerTemplateUrl: "@"
         },
         template: function (elem, attrs) {
           function dashCase(name) {
@@ -121,6 +124,8 @@ angular.module('ui.bootstrap.datetimepicker', ["ui.bootstrap.dateparser", "ui.bo
               "dateNgFocus",
               "open($event)") +
             createEvalAttr("currentText", "currentText") +
+            createEvalAttr("datepickerTemplateUrl", "datepickerTemplateUrl") +
+            createEvalAttr("datepickerPopupTemplateUrl", "datepickerPopupTemplateUrl") +
             createEvalAttr("clearText", "clearText") +
             createEvalAttr("datepickerAppendToBody", "datepickerAppendToBody") +
             createEvalAttr("closeText", "closeText") +
@@ -138,6 +143,7 @@ angular.module('ui.bootstrap.datetimepicker', ["ui.bootstrap.dateparser", "ui.bo
               ["ngDisabled", "readonlyTime"]
             ].reduce(createAttrConcat, '') +
             createEvalAttr("showSpinners", "showSpinners") +
+            createEvalAttr("templateUrl", "timepickerTemplateUrl") +
             "></div>\n" +
             "</div>";
           // form is isolated so the directive is registered as one component in the parent form (not date and time)


### PR DESCRIPTION
This PR adds the following options to change the default templates for each picker.
- datepicker-popup-template-url
- datepicker-template-url
- timepicker-template-url

All of these options have been supported since version 1.2.4 of angular-bootstrap (the minimum version required by this package)